### PR TITLE
Update wallaby.js

### DIFF
--- a/wallaby.js
+++ b/wallaby.js
@@ -2,10 +2,12 @@ const webpackConfig = require('./build/webpack.test.conf.js')
 const wallabyWebpack = require('wallaby-webpack')
 
 module.exports = function (wallaby) {
+  webpackConfig.resolve.alias['@'] = require('path').join(wallaby.projectCacheDir, 'src');
   const wallabyPostprocessor = wallabyWebpack(webpackConfig)
 
   return {
     files: [
+      {pattern: '.babelrc', load: false},
       {pattern: 'node_modules/babel-polyfill/dist/polyfill.js', instrument: false},
       {pattern: 'src/**/*.*', load: false}
     ],


### PR DESCRIPTION
Pointing wallaby webpack config to wallaby cache (as opposed to the local project), so that `.vue` file changes result in test re-runs.