### PR TITLE
Single file component code coverage support in wallaby

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "vue-loader": "^12.2.2",
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.2.6",
+    "wallaby-vue-compiler": "^1.0.2",
     "wallaby-webpack": "0.0.38",
     "webpack": "^3.3.0",
     "webpack-bundle-analyzer": "^2.2.1",

--- a/wallaby.js
+++ b/wallaby.js
@@ -2,12 +2,15 @@ const webpackConfig = require('./build/webpack.test.conf.js')
 const wallabyWebpack = require('wallaby-webpack')
 
 module.exports = function (wallaby) {
-  webpackConfig.resolve.alias['@'] = require('path').join(wallaby.projectCacheDir, 'src');
+  webpackConfig.resolve.alias = {'@': require('path').join(wallaby.projectCacheDir, 'src')}
+  webpackConfig.externals = {vue: 'Vue'}
+  webpackConfig.module.rules.find(r => r.loader === 'vue-loader').options.loaders.js = ''
+
   const wallabyPostprocessor = wallabyWebpack(webpackConfig)
 
   return {
     files: [
-      {pattern: '.babelrc', load: false},
+      {pattern: 'node_modules/vue/dist/vue.js', instrument: false},
       {pattern: 'node_modules/babel-polyfill/dist/polyfill.js', instrument: false},
       {pattern: 'src/**/*.*', load: false}
     ],
@@ -23,6 +26,10 @@ module.exports = function (wallaby) {
     postprocessor: wallabyPostprocessor,
 
     setup: function () {
+      // eslint-disable-next-line
+      Vue.config.errorHandler = function (err) {
+        throw err
+      }
       window.__moduleBundler.loadTests()
     },
 
@@ -30,7 +37,8 @@ module.exports = function (wallaby) {
       ignoreCoverage: /ignore coverage/
     },
     compilers: {
-      '**/*.js': wallaby.compilers.babel()
+      '**/*.js': wallaby.compilers.babel(),
+      '**/*.vue': require('wallaby-vue-compiler')(wallaby.compilers.babel({}))
     },
     debug: true
   }


### PR DESCRIPTION
After merging the changes, the template users will get wallaby intel for `.vue` files scripts:

![vue](https://user-images.githubusercontent.com/979966/28302901-7acd191c-6bd3-11e7-82d5-83a5f2a5a988.gif)