### PR TITLE
Added eslint-plugin-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-standard": "^3.0.1",
+    "eslint-plugin-node": "5.2.1",
     "eventsource-polyfill": "^0.9.6",
     "express": "^4.14.1",
     "extract-text-webpack-plugin": "^3.0.0",


### PR DESCRIPTION
When running the project for the first time after an `npm install` it fails to run.

Added eslint-plugin-node to fix required dependency.